### PR TITLE
Added account id and account password to the control panel

### DIFF
--- a/src/bda/plone/shop/cartdata.py
+++ b/src/bda/plone/shop/cartdata.py
@@ -114,6 +114,18 @@ class CartDataProvider(CartItemCalculator, CartDataProviderBase):
         return settings.shop_show_to_cart
         
     @property
+    def shop_account_password(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IBdaShopSettings)
+        return settings.shop_account_password
+        
+    @property
+    def shop_account_id(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IBdaShopSettings)
+        return settings.shop_account_id
+        
+    @property
     def disable_max_article(self):
         return True
 

--- a/src/bda/plone/shop/interfaces.py
+++ b/src/bda/plone/shop/interfaces.py
@@ -32,7 +32,7 @@ class IBdaShopSettings(Interface):
                         description=_(u"help_shop_account_id", default=u'The account ID at https://www.saferpay.com/ or similar service'),
                         required=False,
                         default="99867-94913159")    
-                        
+
     shop_account_password = schema.ASCIILine(title=_(u"label_shop_account_password", default=u'Account Password'),
                               description=_(u"help_shop_account_password", default=u'The account password at https://www.saferpay.com/ or similar service'),
                               required=False,
@@ -64,7 +64,4 @@ class IBdaShopSettings(Interface):
     shop_show_to_cart = schema.Bool(title=u"Show link to cart in portlet", 
                                    description=u"", 
                                    default=True)
-                                   
-                                   
-                                   ACCOUNTID = "99867-94913159"
-PASSWORD = "XAjc3Kna"
+                               

--- a/src/bda/plone/shop/profiles/default/registry.xml
+++ b/src/bda/plone/shop/profiles/default/registry.xml
@@ -10,6 +10,7 @@
       </value>
       <value key="shop_show_checkout">False</value>
       <value key="shop_show_to_cart">True</value>
-      
+      <value key="shop_account_id"></value>
+      <value key="shop_account_password"></value>
     </records>
 </registry>


### PR DESCRIPTION
The account id and password is currently hard coded into files in bda.shop.payment. 
These should be changed to use the settings from the control panel

Warning: The default values are those I found in module six_payment and these should be changed before publishing the product. It is also important that these credentials are removed from the six_payment modoule.
