### PR TITLE
Added account id and account password to the control panel

### DIFF
--- a/src/bda/plone/shop/cartdata.py
+++ b/src/bda/plone/shop/cartdata.py
@@ -113,16 +113,10 @@ class CartDataProvider(CartItemCalculator, CartDataProviderBase):
         return settings.shop_show_to_cart
         
     @property
-    def shop_account_password(self):
+    def shop_show_currency_in_cart(self):
         registry = getUtility(IRegistry)
         settings = registry.forInterface(IShopSettings)
-        return settings.shop_account_password
-        
-    @property
-    def shop_account_id(self):
-        registry = getUtility(IRegistry)
-        settings = registry.forInterface(IShopSettings)
-        return settings.shop_account_id
+        return settings.shop_show_currency_in_cart
 
     @property
     def disable_max_article(self):

--- a/src/bda/plone/shop/interfaces.py
+++ b/src/bda/plone/shop/interfaces.py
@@ -29,24 +29,17 @@ class IBuyable(Interface):
 
 
 AVAILABLE_CURRENCIES = [
-    "EUR", "USD", "INR", "CAD", "CHF", "GBP", "AUD", "NOK", "SEK", "DKK",
+    "EUR", "USD", "INR", "CAD", "CHF", "GBP", "AUD", "NOK", "SEK", "DKK", "YEN",
 ]
 
+CART_CURRENCIES_ANSWERS = [
+    "Yes", "No", "Symbol",
+]
 
 class IShopSettings(Interface):
     """Shop controlpanel schema.
     """
 
-    shop_account_id = schema.ASCIILine(title=_(u"label_shop_account_id", default=u'Account ID'),
-        description=_(u"help_shop_account_id", default=u'The account ID at https://www.saferpay.com/ or similar service'),
-        required=False,
-        default="99867-94913159")    
-
-    shop_account_password = schema.ASCIILine(title=_(u"label_shop_account_password", default=u'Account Password'),
-        description=_(u"help_shop_account_password", default=u'The account password at https://www.saferpay.com/ or similar service'),
-        required=False,
-        default="XAjc3Kna")    
-                              
     shop_vat=schema.List(
         title=_(u"Specify all allowed vat settings, one per line. "
                 u"The required format is <name> <persentage>"),
@@ -65,8 +58,7 @@ class IShopSettings(Interface):
     shop_currency = schema.Choice(
         title=u"Currency",
         description=u"Choose the default currency",
-        values=AVAILABLE_CURRENCIES,
-        default='EUR')
+        values=AVAILABLE_CURRENCIES)
 
     shop_show_checkout = schema.Bool(
         title=u"Show checkout link in portlet",
@@ -77,3 +69,16 @@ class IShopSettings(Interface):
         title=u"Show link to cart in portlet",
         description=u"",
         default=True)
+        
+    shop_show_currency_in_cart = schema.Choice(
+        title=u"Show the currency for items in portlet",
+        description=u"",
+        values=CART_CURRENCIES_ANSWERS)
+        
+    shop_quantity_units=schema.List(
+        title=_(u"Specify all allowed quantity settins. "
+                u"The required format is <name>. No spaces, please"),
+        description=_(u"help_shop_quantity_units", default=u'Quantity units (what the buyable items are measured in)'),
+        required=True,
+        value_type=schema.TextLine(),
+        default=[])

--- a/src/bda/plone/shop/profiles/default/registry.xml
+++ b/src/bda/plone/shop/profiles/default/registry.xml
@@ -2,16 +2,21 @@
 <registry>
   <records interface="bda.plone.shop.interfaces.IShopSettings">
     <value key="shop_currency">EUR</value>
-    <value key="shop_admin_email">some@email.com</value>
+    <value key="shop_admin_email"></value>
     <value key="shop_vat">
       <element>0% 0</element>
       <element>10% 10</element>
       <element>20% 20</element>
       <element>25% 25</element>
     </value>
+    <value key="shop_quantity_units">
+      <element>quantity</element>
+      <element>meter</element>
+      <element>kilo</element>
+      <element>liter</element>     
+    </value>
     <value key="shop_show_checkout">False</value>
     <value key="shop_show_to_cart">True</value>
-    <value key="shop_account_id"></value>
-    <value key="shop_account_password"></value>
+    <value key="shop_show_currency_in_cart">Symbol</value>
   </records>
 </registry>

--- a/src/bda/plone/shop/vocabularies.py
+++ b/src/bda/plone/shop/vocabularies.py
@@ -9,15 +9,18 @@ from .interfaces import IShopSettings
 
 _ = MessageFactory('bda.plone.shop')
 
-
+#capitalizing should be done in css
 def QuantityUnitVocabulary(context):
-    items = [
-        (_('quantity', default='Quantity'), 'quantity'),
-        (_('meter', default='Meter'), 'meter'),
-        (_('kilo', default='Kilo'), 'kilo'),
-        (_('liter', default='Liter'), 'liter')]
+    settings = getUtility(IRegistry).forInterface(IShopSettings)
+    if not settings:
+        return
+    items = []
+    for line in settings.shop_quantity_units:
+        if not line:
+            continue
+        line = line.split()
+        items.append((line[0], line[0]))
     return SimpleVocabulary.fromItems(items)
-
 
 directlyProvides(QuantityUnitVocabulary, IVocabularyFactory)
 


### PR DESCRIPTION
The account id and password is currently hard coded into files in bda.shop.payment. 
These should be changed to use the settings from the control panel

Warning: The default values are those I found in module six_payment and these should be changed before publishing the product. It is also important that these credentials are removed from the six_payment modoule.
