### PR TITLE
Fix #55: use a newer version of z3c.form to make ordered select widget work

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -30,6 +30,10 @@ find-links +=
 [versions]
 plone.app.workflow = 2.1.9
 plone.app.users = 2.1.0
+# XXX: use a newer version to make the ordered select input widget work:
+# https://github.com/bluedynamics/bda.plone.shop/issues/55
+# Remove when z3c.form is updated in Plone.
+z3c.form = 3.2.6
 
 # robot
 #plone.app.robotframework = 0.9.1

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,11 @@ setup(
         'Plone',
         'plone.api',
         'plone.app.registry',
-        'plone.app.users',
+        'plone.app.users>=2.0',
+        'plone.app.workflow>=2.1.9',
         'setuptools',
         'zope.deferredimport',
+        'z3c.form>=3.2.4',  # Issue #55
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
This provides a fix for #55 by upgrading to a newer z3c.form. The bug was fixed in z3c.form version 3.2.4 (https://pypi.python.org/pypi/z3c.form#id15), but should be fine to use the newest version (3.2.6). The tests pass except for one robot test, but it's not related to this change.

This commit can be reverted when z3c.form is upgraded in Plone.