### PR TITLE
Do not resort IPropertiesPlugin, bda.plone.shop must be last.

### DIFF
--- a/src/bda/plone/shop/setuphandlers.py
+++ b/src/bda/plone/shop/setuphandlers.py
@@ -35,12 +35,6 @@ def add_plugin(pas, plugin_id=PAS_ID):
     # Activate the Plugin
     pas.plugins.activatePlugin(IPropertiesPlugin, plugin.getId())
 
-    # Make it the last Plugin in the list of PropertiesPlugin - FIFO.
-    pas.plugins.movePluginsDown(
-        IPropertiesPlugin,
-        [x[0] for x in pas.plugins.listPlugins(IPropertiesPlugin)[:-1]],
-    )
-
     return PAS_TITLE + " installed."
 
 


### PR DESCRIPTION
The sorting code which i copied from c.smsauthtenticator makes the ``bda.plone.shop PAS plugin`` the first. I removed that as it needs to be last to make it work.

Signed-off-by: Rene Jochum <rene@jochums.at>