### PR TITLE
plone.api v130 is needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'bda.plone.orders',
         'collective.z3cform.datagridfield',
         'Plone',
-        'plone.api',
+        'plone.api>=1.3.0',
         'plone.app.registry',
         'plone.app.users>=2.0',
         'plone.app.workflow>=2.1.9',


### PR DESCRIPTION
As api.user.has_permission is used plone.api version 1.3.0 and higher
needed.