### PR TITLE
context.default_page instead of container.default_page

### DIFF
--- a/src/bda/plone/shop/browser/navigation.py
+++ b/src/bda/plone/shop/browser/navigation.py
@@ -159,8 +159,7 @@ class ShopNavigationLink(object):
         """Return flag whether given context is default page in it's container.
         """
         context = aq_inner(context)
-        container = aq_parent(context)
-        to_adapt = container, self.request
+        to_adapt = context, self.request
         default_page = getMultiAdapter(to_adapt, name='default_page')
         return default_page.getDefaultPage() == context.getId()
 

--- a/src/bda/plone/shop/browser/navigation.py
+++ b/src/bda/plone/shop/browser/navigation.py
@@ -159,7 +159,8 @@ class ShopNavigationLink(object):
         """Return flag whether given context is default page in it's container.
         """
         context = aq_inner(context)
-        to_adapt = context, self.request
+        container = aq_parent(context)
+        to_adapt = container, self.request
         default_page = getMultiAdapter(to_adapt, name='default_page')
         return default_page.getDefaultPage() == context.getId()
 

--- a/src/bda/plone/shop/browser/navigation.py
+++ b/src/bda/plone/shop/browser/navigation.py
@@ -159,6 +159,8 @@ class ShopNavigationLink(object):
         """Return flag whether given context is default page in it's container.
         """
         context = aq_inner(context)
+        if IPloneSiteRoot.providedBy(context):
+            return False
         container = aq_parent(context)
         to_adapt = container, self.request
         default_page = getMultiAdapter(to_adapt, name='default_page')


### PR DESCRIPTION
Fix for #104:
Drop the aq_parent step when computing the default page.
In Plone 4.3.15 and with LinguaPlone 4.2.1 installed, the former  code
tried to get the 'portal_languages' tool in the Zope root (instead of
the Plone site root) when e.g. the @@shop_controlpanel was opened in the
site root.

In any case, in this regard it looks more plausible to me
to inspect the context than the container.